### PR TITLE
feat: add `link` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ BMO has a number of commands, here you'll find a list of them with the link to m
 - [rest](https://github.com/estarossa0/bmo/blob/master/docs/commands/rest.md)
 - [echo](https://github.com/estarossa0/bmo/blob/master/docs/commands/echo.md)
 - [ping](https://github.com/estarossa0/bmo/blob/master/docs/commands/ping.md)
+- [link](https://github.com/estarossa0/bmo/blob/master/docs/commands/link.md)
 
 (type "/" anywhere in discord server and you'll see a list of commands with small description)
 

--- a/docs/commands/link.md
+++ b/docs/commands/link.md
@@ -1,0 +1,18 @@
+### Description
+
+Gives you the link to the student's 42 intra with additional informations.
+
+- Full name
+- Campus
+- Level
+
+### Arguments
+
+- username:
+  - description: the student username
+  - required: ✅
+  - type: _string_
+
+### How it works
+
+It fetch `/v2/users/:id` route from 42 api and get the needed information about the user along with the 42 intra link.

--- a/src/discord/commands/link.ts
+++ b/src/discord/commands/link.ts
@@ -1,0 +1,74 @@
+import { MessageEmbed } from "discord.js";
+import type { Command } from "../../types";
+import got from "got";
+
+const command: Command = {
+  name: "link",
+  description: "give 42 intra link for the USERNAME",
+  options: [
+    {
+      type: "STRING",
+      name: "username",
+      required: true,
+      description: "the user you wanna get his 42 intra link",
+    },
+  ],
+  async execute(interaction) {
+    const embedReply = new MessageEmbed();
+    const userName = interaction.options.data.find(
+      (arg) => arg.name === "username",
+    )?.value;
+
+    const userData = await got(`https://api.intra.42.fr/v2/users/${userName}`, {
+      headers: {
+        Authorization: `Bearer ${process.env.INTRA_TOKEN}`,
+      },
+      throwHttpErrors: false,
+    }).then(async (response) => {
+      if (response.statusCode != 200) {
+        if (response.statusCode === 404) return null;
+
+        throw new Error();
+      }
+      return JSON.parse(response.body);
+    });
+
+    if (userData === null) {
+      interaction.reply({
+        content: "Username not found",
+        ephemeral: process.env.EPHEMERAL === "true",
+      });
+    }
+    embedReply
+      .setColor("#00babc")
+      .setTitle(
+        typeof userData.displayname === "string"
+          ? userData.displayname
+          : "Title",
+      )
+      .setURL(`https://profile.intra.42.fr/users/${userName}`)
+      .setThumbnail(userData.image_url)
+      .addFields(
+        {
+          name: "Campus",
+          value: userData.campus.find((campus: any) => campus.active === true)
+            .name,
+          inline: true,
+        },
+        {
+          name: "Level",
+          value: userData.cursus_users
+            .find((cursus: any) => cursus.end_at === null)
+            .level.toString(),
+          inline: true,
+        },
+      );
+
+    await interaction.reply({
+      embeds: [embedReply],
+      ephemeral: process.env.EPHEMERAL === "true",
+    });
+  },
+};
+
+export default command;


### PR DESCRIPTION
I implemented the `link` command per issue #9 .

### Description

Gives you the link to the student's 42 intra with additional informations.

- Full name
- Campus
- Level

### Arguments

- username:
  - description: the student username
  - required: ✅
  - type: _string_

### How it works

It fetch `/v2/users/:id` route from 42 api and get the needed information about the user along with the 42 intra link.
